### PR TITLE
Add isDeleting property to WorkoutData interface

### DIFF
--- a/client/src/lib/database.ts
+++ b/client/src/lib/database.ts
@@ -11,6 +11,7 @@ export interface WorkoutData {
     }>;
   }>;
   completedAt: string;
+  isDeleting?: boolean;
 }
 
 export const saveWorkout = async (workoutData: WorkoutData): Promise<string> => {


### PR DESCRIPTION
Assistant generated file changes:
- client/src/lib/database.ts: Add isDeleting property to WorkoutData interface

---

User prompt:

Running the code in my project results in the following:

```

> rest-express@1.0.0 dev
> tsx watch --clear-screen=false server/index.ts

02:53:26 PM [express] serving on port 5000

 ERROR(TypeScript)  Property 'isDeleting' does not exist on type 'WorkoutData'.
 FILE  /home/runner/WorkoutTracker/client/src/pages/HistoryPage.tsx:168:27

    166 |                 key={workout.id}
    167 |                 className={`p-4 w-full max-w-3xl mx-auto transition-all duration-300 ease-in-out transform ${
  > 168 |                   workout.isDeleting ? 'opacity-0 -translate-x-full' : 'opacity-100 translate-x-0'
        |                           ^^^^^^^^^^
    169 |                 }`}
    170 |               >
    171 |                 <div className="flex justify-between items-start mb-2">

[TypeScript] Found 1 error. Watching for file changes.
```

If applicable, propose a fix immediately.